### PR TITLE
Adds a main file with argument parsing

### DIFF
--- a/buildResults.py
+++ b/buildResults.py
@@ -3,12 +3,12 @@ import sys
 import csv
 import statistics
 
-ALL_RESULT_HELPER = sys.argv[1]
+ALL_RESULTS_HELPER="all_results/runs.describe.txt"
 
 if not os.path.exists("results"):
     os.mkdir("results")
 
-with open(ALL_RESULT_HELPER, "r") as runs_describer:
+with open(ALL_RESULTS_HELPER, "r") as runs_describer:
     for _line in runs_describer:
 
         # topic execution_number result_file

--- a/colors
+++ b/colors
@@ -1,29 +1,30 @@
 #!/bin/bash
 
-RED=""
-GREEN=""
-BLUE=""
-WHITE=""
-MAGENTA=""
-YELLOW=""
+COLORS_ON=true
+
+if ! $COLORS_ON; then
+    RED=""
+    GREEN=""
+    BLUE=""
+    WHITE=""
+    MAGENTA=""
+    YELLOW=""
+
+    END=""
+
+else
+    RED="\e[31;1m"
+    GREEN="\e[32;1m"
+    BLUE="\e[34;1m"
+    WHITE="\e[37;1m"
+    MAGENTA="\e[35;1m"
+    YELLOW="\e[33;1m"
+
+    END="\e[0m"
+fi
 
 
-END=""
-
-: '
-# Uncomment to show colors
-RED="\e[31;1m"
-GREEN="\e[32;1m"
-BLUE="\e[34;1m"
-WHITE="\e[37;1m"
-MAGENTA="\e[35;1m"
-YELLOW="\e[33;1m"
-
-
-END="\e[0m"
-'
-
-declare -A COLORS=( ["red"]="\e[31;1m" ["green"]="\e[32;1m" ["blue"]="\e[34;1m" ["white"]="\e[37;1m" ["magenta"]="\e[35;1m" ["yellow"]="\e[33;1m");
+declare -A COLORS=( ["red"]=$RED ["green"]=$GREEN ["blue"]=$BLUE ["white"]=$WHITE ["magenta"]=$MAGENTA ["yellow"]=$YELLOW);
 
 e_error () {
     echo -e "${COLORS[red]}${1}${END}";

--- a/doAll_Baseline_4gram
+++ b/doAll_Baseline_4gram
@@ -17,7 +17,6 @@ else
 fi
 
 
-exit
 
 source "${ABS_PATH}/handle_errors"
 source "${ABS_PATH}/colors"

--- a/main
+++ b/main
@@ -71,7 +71,7 @@ CORPUS="toyDataset"
 DEBUG_MODE="n"
 TOPICS_CONSIDERED="empty"      # dummy value for empty topic list verification
 
-sed -r -i "s/COLORS_ON=false/COLORS_ON=true/"
+sed -r -i "s/COLORS_ON=false/COLORS_ON=true/" colors
 
 #----------------------------------------------------------------------
 # space separated argument parsing
@@ -188,6 +188,6 @@ done
 
 e_info "Finished taking results...\nComputing mean and standard deviation of samples."
 
-python3 buildResults.py                         # takes mean and standard deviations
+python3 buildResults.py                               # takes mean and standard deviations
 
-sed -r -i "s/COLORS_ON=false/COLORS_ON=true/"   # resets color option
+sed -r -i "s/COLORS_ON=false/COLORS_ON=true/" colors  # resets color option

--- a/main
+++ b/main
@@ -1,0 +1,183 @@
+#!/bin/bash
+#===============================================================================
+#       USAGE:  ./main [options] (see usage function below)
+#
+# DESCRIPTION:  Performs the management of the other resources, providing
+#               argument parsing.
+#===============================================================================
+
+export ABS_PATH=`pwd`
+
+source "${ABS_PATH}/handle_errors"
+source "${ABS_PATH}/colors"
+
+#=== FUNCTION =============================================
+# Display usage information for this script.
+#
+# Parameters:
+#    None
+#==========================================================
+function show_usage() {
+    echo "Usage: ./main [-s <samples>|--samples=<samples>]
+                        [-c <corpus>|--corpus=<corpus>] [-d|--debug]
+                        [-o|--off-colors] [-t <topic-list>|--topics <topic-list>]
+                        [-h|--help]"
+}
+
+#=== FUNCTION =============================================
+# Display detailed information about command options and
+# its parameters
+#
+# Parameters:
+#    None
+#==========================================================
+function show_help() {
+    show_usage
+
+    echo "-s <samples>, --samples=<samples>"
+    echo "      Set <samples> as the quantity of executions that will occurs."
+    echo "      After, the mean and standard deviation over the samples are taken."
+    echo "      The standard value is 1."
+
+    echo ""
+    echo "-c <corpus>, --corpus=<corpus>"
+    echo "      Specifies the name of the corpus to be used."
+
+    echo ""
+    echo "-t <topic-list>, --topics=<topic-list>"
+    echo "      Specifies which topics will be computed by the method."
+    echo "      <topic-list> must be a space separated string, containing"
+    echo "      one or more topics."
+
+    echo ""
+    echo "-d, --debug"
+    echo "      If specified, turns on the debug mode, showing verbose messages."
+
+    echo ""
+    echo "-o, --off-colors"
+    echo "      Turns off colors of terminal outputs."
+
+    echo ""
+    echo "-h, --help"
+    echo "      Show this message."
+}
+
+
+#----------------------------------------------------------------------
+# set standard values
+#----------------------------------------------------------------------
+POSITIONAL=()
+SAMPLES=1
+CORPUS="toyDataset"
+DEBUG_MODE="n"
+TOPICS_CONSIDERED="empty"
+
+#----------------------------------------------------------------------
+# space separated argument parsing
+#----------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    key=$1; shift
+
+    case $key in
+        -s )
+            SAMPLES=$1
+            shift
+            ;;
+
+        -c )
+            CORPUS=$1
+            shift
+            ;;
+
+        -t )
+            declare -a TOPICS_CONSIDERED=($1)
+            shift
+            ;;
+
+        -d | --debug )
+            DEBUG_MODE="y"
+            ;;
+
+        -o | --off-colors )
+            COLORS=false
+            ;;
+
+        -h | --help )
+            show_help
+            exit
+            ;;
+
+        * )
+            POSITIONAL+=("$key")
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL[@]}"
+
+#----------------------------------------------------------------------
+# equals separated argument parsing
+#----------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    key=$1; shift
+
+    case $key in
+        --samples=* )
+            SAMPLES="${key#*=}"
+            shift
+            ;;
+
+        --corpus=* )
+            CORPUS="${key#*=}"
+            shift
+            ;;
+
+        --topics=* )
+            topics="${key#*=}"
+            declare -a TOPICS_CONSIDERED=($topics)
+            ;;
+
+        * )
+            echo "Unknown option '$key'."
+            show_usage
+            exit
+            ;;
+    esac
+done
+
+#----------------------------------------------------------------------
+# prepare directories, runs main code
+#----------------------------------------------------------------------
+RESULT_DIR="result/baseline"
+ALL_RESULTS_HELPER="all_results/runs.describe.txt"
+
+rm -rf all_results
+mkdir all_results
+
+rm -rf results
+mkdir results
+
+for i in $(seq -f "%02g" ${SAMPLES}); do
+
+    echo -e "${MAGENTA}Running sample ${i}.${END}"
+
+    rm -rf all_results/result-${i}
+    mkdir all_results/result-${i}
+
+    if [ -f "$CORPUS.svm.fil" ]; then
+        bash doAll_Baseline_4gram true $CORPUS $DEBUG_MODE "${TOPICS_CONSIDERED[@]}"
+
+    else
+        bash doAll_Baseline_4gram false $CORPUS $DEBUG_MODE "${TOPICS_CONSIDERED[@]}"
+    fi
+
+    for topic in `ls ${RESULT_DIR}/${CORPUS}/`; do
+        cp "${RESULT_DIR}/${CORPUS}/${topic}/rel.rate" all_results/result-${i}/rel.${topic}.rate
+
+        echo "${topic} ${i} all_results/result-${i}/rel.${topic}.rate" >> $ALL_RESULTS_HELPER
+    done
+done
+
+echo -e "${MAGENTA}Finished taking results...\nComputing mean and standard deviation of samples.${END}"
+
+python3 buildResults.py

--- a/main
+++ b/main
@@ -9,7 +9,6 @@
 export ABS_PATH=`pwd`
 
 source "${ABS_PATH}/handle_errors"
-source "${ABS_PATH}/colors"
 
 #=== FUNCTION =============================================
 # Display usage information for this script.
@@ -19,9 +18,9 @@ source "${ABS_PATH}/colors"
 #==========================================================
 function show_usage() {
     echo "Usage: ./main [-s <samples>|--samples=<samples>]
-                        [-c <corpus>|--corpus=<corpus>] [-d|--debug]
-                        [-o|--off-colors] [-t <topic-list>|--topics <topic-list>]
-                        [-h|--help]"
+              [-c <corpus>|--corpus=<corpus>] [-d|--debug]
+              [-o|--off-colors] -t <topic-list>|--topics <topic-list>
+              [-h|--help]"
 }
 
 #=== FUNCTION =============================================
@@ -34,31 +33,31 @@ function show_usage() {
 function show_help() {
     show_usage
 
-    echo "-s <samples>, --samples=<samples>"
+    e_secondary "-s <samples>, --samples=<samples>"
     echo "      Set <samples> as the quantity of executions that will occurs."
     echo "      After, the mean and standard deviation over the samples are taken."
     echo "      The standard value is 1."
 
     echo ""
-    echo "-c <corpus>, --corpus=<corpus>"
+    e_secondary "-c <corpus>, --corpus=<corpus>"
     echo "      Specifies the name of the corpus to be used."
 
     echo ""
-    echo "-t <topic-list>, --topics=<topic-list>"
+    e_secondary "-t <topic-list>, --topics=<topic-list>"
     echo "      Specifies which topics will be computed by the method."
     echo "      <topic-list> must be a space separated string, containing"
     echo "      one or more topics."
 
     echo ""
-    echo "-d, --debug"
+    e_secondary "-d, --debug"
     echo "      If specified, turns on the debug mode, showing verbose messages."
 
     echo ""
-    echo "-o, --off-colors"
+    e_secondary "-o, --off-colors"
     echo "      Turns off colors of terminal outputs."
 
     echo ""
-    echo "-h, --help"
+    e_secondary "-h, --help"
     echo "      Show this message."
 }
 
@@ -66,11 +65,13 @@ function show_help() {
 #----------------------------------------------------------------------
 # set standard values
 #----------------------------------------------------------------------
-POSITIONAL=()
+POSITIONAL=()                   # stores not recognized parameters
 SAMPLES=1
 CORPUS="toyDataset"
 DEBUG_MODE="n"
-TOPICS_CONSIDERED="empty"
+TOPICS_CONSIDERED="empty"      # dummy value for empty topic list verification
+
+sed -r -i "s/COLORS_ON=false/COLORS_ON=true/"
 
 #----------------------------------------------------------------------
 # space separated argument parsing
@@ -99,7 +100,8 @@ while [[ $# -gt 0 ]]; do
             ;;
 
         -o | --off-colors )
-            COLORS=false
+            sed -r -i "s/COLORS_ON=true/COLORS_ON=false/" colors
+            source "${ABS_PATH}/colors"
             ;;
 
         -h | --help )
@@ -138,12 +140,18 @@ while [[ $# -gt 0 ]]; do
             ;;
 
         * )
-            echo "Unknown option '$key'."
+            e_error "Unknown option '$key'."
             show_usage
             exit
             ;;
     esac
 done
+
+if [[ $TOPICS_CONSIDERED == "empty" ]]; then
+    e_error "Topics must be explicitly specified, but none where given."
+    show_usage
+    exit
+fi
 
 #----------------------------------------------------------------------
 # prepare directories, runs main code
@@ -159,7 +167,7 @@ mkdir results
 
 for i in $(seq -f "%02g" ${SAMPLES}); do
 
-    echo -e "${MAGENTA}Running sample ${i}.${END}"
+    e_info "Running sample ${i}."
 
     rm -rf all_results/result-${i}
     mkdir all_results/result-${i}
@@ -178,6 +186,8 @@ for i in $(seq -f "%02g" ${SAMPLES}); do
     done
 done
 
-echo -e "${MAGENTA}Finished taking results...\nComputing mean and standard deviation of samples.${END}"
+e_info "Finished taking results...\nComputing mean and standard deviation of samples."
 
-python3 buildResults.py
+python3 buildResults.py                         # takes mean and standard deviations
+
+sed -r -i "s/COLORS_ON=false/COLORS_ON=true/"   # resets color option


### PR DESCRIPTION
closes #15 

Adds a new bash script file `main` with argument parsing to a better parameter customization.

**NOTE:** Type `./main --help` and try to execute and understand the options without additional help. If it doesn't go well, it means that the help message must be improved.