### PR TITLE
Complete code spliting

### DIFF
--- a/doAll_Baseline_4gram
+++ b/doAll_Baseline_4gram
@@ -1,571 +1,237 @@
 #!/bin/bash
 
-JUDGECLASS=$1; shift
-DEBUG_MODE=false; [[ $1 == "true" ]] && DEBUG_MODE=true; shift
-TOPIC=$1; shift
-QUERY=$1; shift
-rules=5
-TEMP=$(mktemp)
-
-source "${ABS_PATH}/handle_errors"
-source "${ABS_PATH}/colors"
-
-
-RESULT_DIR="result/${JUDGECLASS}"
-
-SOFIA="${ABS_PATH}/sofia-ml-read-only/sofia-ml"
-
-$DEBUG_MODE && echo $JUDGECLASS
-
-
-######
-$DEBUG_MODE && echo "Creating directories to store results..."
-
-try
-(
-    rm -rf "${RESULT_DIR}/${TOPIC}/"
-    mkdir -p "${RESULT_DIR}/${TOPIC}/"
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-
-$DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-$DEBUG_MODE && echo -e "${BLUE}Creating topic directory topic (${TOPIC})...${END}"
-
-######
-try
-(
-    rm -rf $TOPIC
-    mkdir $TOPIC
-    #echo "cat judgement/qrels.$JUDGECLASS.list | grep $TOPIC  | cut -d' ' -f3 > $TOPIC/goldendb"
-    cat judgement/qrels.$JUDGECLASS.list | grep $TOPIC  | cut -d' ' -f3 | sort > $TOPIC/goldendb
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-
-$DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-$DEBUG_MODE && echo "Creating file 'N' with number of documents..."
-
-######
-
-try
-(
-    : '
-        Creates a `N` file with number of all docs
-    '
-    echo `wc -l < "$JUDGECLASS".svm.fil` > N
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-
-$DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-$DEBUG_MODE && echo "Preparing 'docfils' file with all documents..."
-
-pushd $TOPIC
-
-echo "$QUERY" > "$TOPIC".seed.doc
-
-######
-ln -n ../$JUDGECLASS.svm.fil $JUDGECLASS.svm.fil
-
-try
-(
-    cut -d' ' -f1 ../$JUDGECLASS.svm.fil | sed -e 's/.*/& &/' > docfil
-    cut -d' ' -f1 docfil | cat -n > docfils
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-$DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-$DEBUG_MODE && echo "Preparing relevance calculation files..."
-
-: '
-    The `new$N` files keeps the files used on
-        the $N-th iteration
-'
-
-######
-try
-(
-    touch rel.$TOPIC.fil
-    touch prel.$TOPIC
-
-    rm -rf prevalence.rate
-    touch prevalence.rate
-
-    rm -rf rel.rate
-    touch rel.rate
-
-    rm -f new[0-9][0-9].$TOPIC tail[0-9][0-9].$TOPIC self*.$TOPIC gold*.$TOPIC
-    touch new00.$TOPIC
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-$DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-
-# Total number of documents
-NDOCS=`cat docfils | wc -l`
-# Number of documents already labeled
-NDUN=0
-# Number of documents to be labeled in the current iteration
-L=1
-
-R=100
-LAMBDA=0.0001
-NotRel=0
-flag_discretize=0
-flag_allac_first_time=0
-: '
-    $TOPIC.seed.doc stores the $TOPIC query
-'
-
-cp $TOPIC.seed.doc ../$TOPIC.seed.doc
-
-popd
-
-$DEBUG_MODE && echo -e "${BLUE}Executing ./dofeaturesseed4...${END}"
-
-./dofeaturesseed $TOPIC.seed.doc $TOPIC $JUDGECLASS $DEBUG_MODE
-
-$DEBUG_MODE && echo -e "${GREEN}Finished ./dofeaturesseed4${END}"
-
-pushd $TOPIC
-
-######
-try
-(
-    sed -e 's/[^ ]*/0/' ../$JUDGECLASS.svm.fil | ../dosplit
-    echo  "Preparing ../$JUDGECLASS.svm.fil (runs ../dosplit) "
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-
-try
-(
-    sed -e 's/[^ ]*/1/' svm.$TOPIC.seed.doc.fil > $TOPIC.synthetic.seed
-    echo  "Preparing $TOPIC.synthetic.seed..."
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-
-
-#key value database kissdb
-    KEYSIZE=$(awk 'BEGIN{a=0}{len = length($1); a=a<len?len:a}END{print a}' $JUDGECLASS.svm.fil)
-    VALSIZE=$(awk 'BEGIN{a=0}{len = length($0); a=a<len?len:a}END{print a}' $JUDGECLASS.svm.fil)
-    KEYSIZE=$((KEYSIZE+2))
-    VALSIZE=$((VALSIZE+2))
-
- try
-(
-
-
-
-
-
-    if [ ! -f "../$JUDGECLASS.db" ]; then
-
-        $DEBUG_MODE && echo "Indexing $JUDGECLASS, keysize = $KEYSIZE, valsize = $VALSIZE"
-
-        ../indexer $JUDGECLASS.svm.fil "$JUDGECLASS".db $KEYSIZE $VALSIZE || (echo "Error creating db"; exit 1)
-    fi
-
-
-) 2> $STD_ERROR_OUT
-
-catch || {
-    exit_on_error
-}
-
-
-
-
-#             fi
-#         fi
-#pushd $TOPIC
-
-$DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-
-
-# for x in 0 1 2 3 4 5 6 7 8 9 ; do
-#     for y in 0 1 2 3 4 5 6 7 8 9 ; do
-#
-#         if [ $NDUN -lt $NDOCS ] ; then
-#             export N=$x$y
-#
-#             echo "Runing round number  $N with $((NDOCS-NDUN)) documents"
-#             ######
-#             $DEBUG_MODE && echo "Preparing trainset..."
-#
+# JUDGECLASS=$1; shift
+# DEBUG_MODE=false; [[ $1 == "true" ]] && DEBUG_MODE=true; shift
+# TOPIC=$1; shift
+# QUERY=$1; shift
+# rules=5
+# TEMP=$(mktemp)
 #
-#             try
-#             (
-#                 cp $TOPIC.synthetic.seed trainset
+# source "${ABS_PATH}/handle_errors"
+# source "${ABS_PATH}/colors"
 #
-#                 cut -f2 docfils | shuf -n $R | sort | .././indexer "$JUDGECLASS".db $KEYSIZE $VALSIZE | sed -e's/[^ ]*/-1/' >> trainset
 #
-#             ) 2> $STD_ERROR_OUT
+# RESULT_DIR="result/${JUDGECLASS}"
 #
-#             catch || {
-#                 exit_on_error
-#             }
+# # SOFIA="${ABS_PATH}/sofia-ml-read-only/sofia-ml"
 #
-#             $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-#             $DEBUG_MODE && echo "Preparing seed (and x)... `wc -l < trainset`"
+# $DEBUG_MODE && echo $JUDGECLASS
 #
-#             ######
-#             try
-#             (
-#                 #cat sub_new[0-9][0-9].$TOPIC > seed
-#                 cat ssarp* > seed
-#                 #cat seed | sort | join - rel.$TOPIC.fil | sed -e 's/^/1 /' > x
-#                 #cat seed | sort | join -v1 - rel.$TOPIC.fil | sort -R | head -50000 | sed -e 's/^/-1 /' >> x
 #
-#                 cat seed | sort | join - rel.$TOPIC.fil | sed -e 's/^/1 /' | sort | uniq > x
-#                 cat seed | sort | join -v1 - rel.$TOPIC.fil | shuf -n 50000 | sed -e 's/^/-1 /' | sort | uniq  >> x
+# ######
+# $DEBUG_MODE && echo "Creating directories to store results..."
 #
-#             ) 2> $STD_ERROR_OUT
+# try
+# (
+#     rm -rf "${RESULT_DIR}/${TOPIC}/"
+#     mkdir -p "${RESULT_DIR}/${TOPIC}/"
 #
-#             catch || {
-#                 exit_on_error
-#             }
+# ) 2> $STD_ERROR_OUT
 #
-#             $DEBUG_MODE && echo -e "${GREEN}Done. ${END} "
-#             $DEBUG_MODE &&  echo "Preparing trainset (pt 2)... `wc -l < trainset`"
+# catch || {
+#     exit_on_error
+# }
 #
-#             ######
-#             try
-#             (
-#                 #sort -k2 x | join -12 - ../$JUDGECLASS.svm.fil | cut -d' ' -f2- | sort -n >> trainset
-#                 cut -d' ' -f2 x | .././indexer $JUDGECLASS.db $KEYSIZE $VALSIZE | cut -d' ' -f2- | paste -d' ' <(cut -d' ' -f1 x) - | sort -n >> trainset
+# $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+# $DEBUG_MODE && echo -e "${BLUE}Creating topic directory topic (${TOPIC})...${END}"
 #
-#             ) 2> $STD_ERROR_OUT
 #
-#             catch || {
-#                 exit_on_error
-#             }
 #
+# try
+# (
+#     rm -rf $TOPIC
+#     mkdir $TOPIC
+#     #echo "cat judgement/qrels.$JUDGECLASS.list | grep $TOPIC  | cut -d' ' -f3 > $TOPIC/goldendb"
+#     cat judgement/qrels.$JUDGECLASS.list | grep $TOPIC  | cut -d' ' -f3 | sort > $TOPIC/goldendb
 #
-#             $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+# ) 2> $STD_ERROR_OUT
 #
-#             # Calculate relevant documents prevalence rate in the traning set
-#             RELTRAINDOC=`grep -E "^1\b" trainset | wc -l`
+# catch || {
+#     exit_on_error
+# }
+#
+# $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+# $DEBUG_MODE && echo "Creating file 'N' with number of documents..."
 #
-#             NOTRELTRAINDOC=`grep -E "^-1\b" trainset | wc -l`
+# ######
+#
+# try
+# (
+#     : '
+#         Creates a `N` file with number of all docs
+#     '
+#     echo `wc -l < "$JUDGECLASS".svm.fil` > N
 #
-#             PREVALENCERATE=`echo "scale=4; $RELTRAINDOC / ($RELTRAINDOC + $NOTRELTRAINDOC)" | bc`
+# ) 2> $STD_ERROR_OUT
 #
-#             echo $RELTRAINDOC $NOTRELTRAINDOC $PREVALENCERATE >> prevalence.rate
+# catch || {
+#     exit_on_error
+# }
 #
-#             ######
-#             $DEBUG_MODE && echo "Training (Running SOFIA-ML)... `wc -l < trainset`"
+# $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+# $DEBUG_MODE && echo "Preparing 'docfils' file with all documents..."
 #
+# pushd $TOPIC
 #
+# echo "$QUERY" > "$TOPIC".seed.doc
 #
-#             try
-#             (
+# ######
+# ln -n ../$JUDGECLASS.svm.fil $JUDGECLASS.svm.fil
 #
+# try
+# (
+#     cut -d' ' -f1 ../$JUDGECLASS.svm.fil | sed -e 's/.*/& &/' > docfil
+#     cut -d' ' -f1 docfil | cat -n > docfils
 #
-#                 $SOFIA --learner_type logreg-pegasos --loop_type roc --lambda $LAMBDA --iterations 2000000 --training_file trainset --dimensionality 3300000  --model_out svm_model &> saida_classificador
+# ) 2> $STD_ERROR_OUT
 #
+# catch || {
+#     exit_on_error
+# }
+# $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+# $DEBUG_MODE && echo "Preparing relevance calculation files..."
 #
-#                 RES=$?
+# : '
+#     The `new$N` files keeps the files used on
+#         the $N-th iteration
+# '
 #
-#             ) 2> $STD_ERROR_OUT
+# ######
+# try
+# (
+#     touch rel.$TOPIC.fil
+#     touch prel.$TOPIC
+#
+#     rm -rf prevalence.rate
+#     touch prevalence.rate
 #
-#             catch || {
-#                 exit_on_error
-#             }
+#     rm -rf rel.rate
+#     touch rel.rate
 #
+#     rm -f new[0-9][0-9].$TOPIC tail[0-9][0-9].$TOPIC self*.$TOPIC gold*.$TOPIC
+#     touch new00.$TOPIC
 #
-#             $DEBUG_MODE && echo -e "${GREEN}Finished SOFIA-ML.${END}"
-#             $DEBUG_MODE &&  echo $RES
+# ) 2> $STD_ERROR_OUT
 #
-#             MAXTHREADS=5
-#             if [[ "$RES" -eq "0" ]] ; then
-#                 for z in svm.test.* ; do
+# catch || {
+#     exit_on_error
+# }
+# $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
 #
-#                     ######
+# # Total number of documents
+# NDOCS=`cat docfils | wc -l`
 #
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
+# #############################
 #
-#                     while [ "$(jobs | grep 'Running' | wc -l)" -ge "$MAXTHREADS" ]; do
-#                         sleep 1
-#                     done
+# : '
+#     $TOPIC.seed.doc stores the $TOPIC query
+# '
 #
+# cp $TOPIC.seed.doc ../$TOPIC.seed.doc
 #
+# popd
 #
-#                     try
-#                     (
+# $DEBUG_MODE && echo -e "${BLUE}Executing ./dofeaturesseed4...${END}"
 #
-#                         $SOFIA --test_file $z --dimensionality 3300000 --model_in svm_model --results_file pout.$z &> saida_classificador &
+# ./dofeaturesseed $TOPIC.seed.doc $TOPIC $JUDGECLASS $DEBUG_MODE
 #
+# $DEBUG_MODE && echo -e "${GREEN}Finished ./dofeaturesseed4${END}"
 #
-#                     ) 2> $STD_ERROR_OUT
+# pushd $TOPIC
 #
-#                     catch || {
-#                         echo $ERROR_CODE
-#                         exit_on_error
-#                     }
+# ######
+# try
+# (
+#     sed -e 's/[^ ]*/0/' ../$JUDGECLASS.svm.fil | ../dosplit
+#     echo  "Preparing ../$JUDGECLASS.svm.fil (runs ../dosplit) "
 #
-#                 done
+# ) 2> $STD_ERROR_OUT
 #
-#                 wait
-#                 #waiting all threads complete their work
+# catch || {
+#     exit_on_error
+# }
 #
-#             else
-#                 ######
+# try
+# (
+#     sed -e 's/[^ ]*/1/' svm.$TOPIC.seed.doc.fil > $TOPIC.synthetic.seed
+#     echo  "Preparing $TOPIC.synthetic.seed..."
 #
-#                 try
-#                 (
-#                     rm -f pout.svm.test.*
-#                     cut -f2      | sort -R | cat -n | sort -k2 | sed -e 's/ */-/' > pout.svm.test.1
+# ) 2> $STD_ERROR_OUT
 #
-#                 ) 2> $STD_ERROR_OUT
+# catch || {
+#     exit_on_error
+# }
 #
 #
-#                 $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+# #key value database kissdb
+#     KEYSIZE=$(awk 'BEGIN{a=0}{len = length($1); a=a<len?len:a}END{print a}' \
+#         $JUDGECLASS.svm.fil)
+#     VALSIZE=$(awk 'BEGIN{a=0}{len = length($0); a=a<len?len:a}END{print a}' \
+#         $JUDGECLASS.svm.fil)
+#     KEYSIZE=$((KEYSIZE+2))
+#     VALSIZE=$((VALSIZE+2))
 #
-#             fi
+#  try
+# (
 #
 #
 #
-#             ######
-#             $DEBUG_MODE && echo "Starting SCAL process $N\nPreparing ranking.$N.$TOPIC..."
 #
 #
-#             try
-#             (
-#                 cat new[0-9][0-9].$TOPIC > seed.$TOPIC
-#                 cut -f1 pout.svm.test.* | ../fixnum | cat -n | join -o2.2,1.2 -t$'\t' - docfils | sort -k1 -n  > inlr.out.$N.$TOPIC
+#     if [ ! -f "../$JUDGECLASS.db" ]; then
 #
-#                 $DEBUG_MODE && echo -e "${BLUE}\tinlr.out size =`wc -l < inlr.out.$N.$TOPIC` docfils  `wc -l <docfils `${END}"
+#         $DEBUG_MODE && echo "Indexing $JUDGECLASS, keysize = $KEYSIZE, valsize = $VALSIZE"
 #
-#                 sort -n seed.$TOPIC > $TEMP
-#                 cat $TEMP | join  -v2 - inlr.out.$N.$TOPIC -2 1 | shuf |  sort -k 2 -r -g -s  > ranking.$N.$TOPIC
+#         ../indexer $JUDGECLASS.svm.fil "$JUDGECLASS".db $KEYSIZE $VALSIZE || (echo "Error creating db"; exit 1)
+#     fi
 #
-#             ) 2> $STD_ERROR_OUT
 #
-#             catch || {
-#                 exit_on_error
-#             }
+# ) 2> $STD_ERROR_OUT
 #
-#             $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+# catch || {
+#     exit_on_error
+# }
 #
-#             $DEBUG_MODE && echo "Preparing new$N.$TOPIC..."
 #
-#             ######
-#             try
-#             (
-#                 $DEBUG_MODE && echo -e "${BLUE}\tranking size `wc -l < ranking.$N.$TOPIC`${END}"
 #
-#                 cat ranking.$N.$TOPIC | cut -d' ' -f1 > new$N.$TOPIC
-#                 cp new$N.$TOPIC U$N
 #
-#                 cat new[0-9][0-9].$TOPIC > x
+# #             fi
+# #         fi
+# #pushd $TOPIC
 #
-#                 if [ "$N" != "99" ] ; then
-#                     head -$L new$N.$TOPIC > $TEMP
-#                     mv $TEMP new$N.$TOPIC
-#                 fi
-#
-#             ) 2> $STD_ERROR_OUT
-#
-#             catch || {
-#                 exit_on_error
-#             }
-#             $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
-#
-#
-#
-#             : '
-#                 x armazena new($N - 1).$TOPIC
-#             '
-#
-#             # Limits the number of documents by 30
-#             if [ $L -le 30 ]; then
-#                 b=$L
-#             else
-#                 b=30
-#             fi
-#
-#             : '
-#                 The files sub_new$N represents a sample of at most 30
-#                     documents from the documents to be used in the iteration.
-#             '
-#             shuf -n $b new$N.$TOPIC > sub_new$N.$TOPIC
-#
-#             $DEBUG_MODE && echo -e "${BLUE}Number of labeled pairs: `wc -l < sub_new$N.$TOPIC`${END}"
-#
-#
-#
-#
-#             # judgefile tells which are the positive docs
-#             python2.7 ../doJudgementMain.py --topic=$TOPIC --judgefile=../judgement/qrels.$JUDGECLASS.list --input=sub_new$N.$TOPIC --output=rel.$TOPIC.$N.Judged.doc.list --record=$TOPIC.record.list
-#
-#             # rel.$TOPIC.Judged.doc.list contains the current relevant docs
-#
-#             cat rel.$TOPIC.$N.Judged.doc.list >> rel.$TOPIC.fil
-#             sort rel.$TOPIC.fil | uniq > $TEMP
-#             mv $TEMP rel.$TOPIC.fil
-#
-#
-#             $DEBUG_MODE && echo -e "${GREEN}Starting active learning${END}"
-#
-#          ############active learning
-#
-#
-#             if [ "$NotRel" -lt 3 ] || [ "$Rel" -lt 1000 ]
-#             then
-#
-#                 echo "store seed in ssarp file"
-#
-#                 cp sub_new$N.$TOPIC ssarp$N.$TOPIC
-#                 cat sub_new$N.$TOPIC  | sort | uniq | join - rel.$TOPIC.fil | cut -d' ' -f1 | sed -e 's/^/1 /' > x_posit.$N
-#
-#                 cat sub_new$N.$TOPIC   | sort | uniq | join - rel.$TOPIC.fil -v1 | cut -d' ' -f1 | sed -e 's/^/-1 /' > x_negat.$N
-#
-#
-#
-#
-#
-#
-#
-#                 cat  x_negat.*   |  sort -k2  | join - ../$JUDGECLASS.svm.fil.svd   -2 1 -1 2 > seed_ssarp.$TOPIC
-#
-#
-#                 cat  x_posit.* | shuf -n 1 | sort -k2  | join - ../$JUDGECLASS.svm.fil.svd  -2 1 -1 2 >> seed_ssarp.$TOPIC
-#
-#
-#                 cut -d ' ' -f2- seed_ssarp.$TOPIC  > seed_ssarpB.$TOPIC
-#     #
-#
-#                 cp x_posit.$N sub_new_positivo.$N
-#                 cp x_negat.$N sub_new_negativo.$N
-#                 ssarp_relevants=`wc -l < x_posit.$N`
-#             else
-#
-#                 echo "creating files"
-#
-#                 cat sub_new$N.$TOPIC | sort | uniq | join - rel.$TOPIC.fil | cut -d' ' -f1 | sed -e 's/^/1 /' > temp_posit.$N.$TOPIC
-#                 cat sub_new$N.$TOPIC | sort | uniq | join - rel.$TOPIC.fil -v1 | cut -d' ' -f1 | sed -e 's/^/-1 /' > temp_negat.$N.$TOPIC
-#
-#
-#                 cat temp_posit.$N.$TOPIC temp_negat.$N.$TOPIC |  sort -k2  | join - ../$JUDGECLASS.svm.fil.svd  -2 1 -1 2 > trainset.$N.$TOPIC
-#                 cut -d ' ' -f2- trainset.$N.$TOPIC  > trainsetB.$N.$TOPIC
-#
-#
-#
-#                 if [ "$flag_discretize" -eq '0' ]
-#                 then
-#                     echo "gerando os bins\n"
-#                     echo "python3 ../svd/convert_txt.py ../$JUDGECLASS.svm.fil.svd /tmp/total.$TOPIC.arff rel.$TOPIC.fil   "
-#                     python3 ../svd/convert_txt.py ../$JUDGECLASS.svm.fil.svd /tmp/total.$TOPIC.arff rel.$TOPIC.fil
-#
-#                     cd ../SSARP/run/
-#                     rm train*
-#                     .././gera_bins_TUBE.sh /tmp/total.$TOPIC.arff  50 10 10
-#                     cd -
-#                     echo "saindo da geração dos bins"
-#                     flag_discretize=1
-#                 fi
-#
-#                 echo "convertendo arquivo para txt"
-#                     python3 ../svd/convert_txt.py trainsetB.$N.$TOPIC out.$N.$TOPIC.arff rel.$TOPIC.fil
-#                     python3 ../svd/convert_txt.py seed_ssarpB.$TOPIC seed_out.$N.$TOPIC.arff rel.$TOPIC.fil
-#
-#
-#                     cp trainset.$N.$TOPIC ../SSARP/run/
-#                     cp seed_out.$N.$TOPIC.arff ../SSARP/run/
-#                     cp out.$N.$TOPIC.arff ../SSARP/run/
-#
-#
-#                 echo "executando alac $rules"
-#                     cd ../SSARP/run/
-#                     ./SSARPX.sh out.$N.$TOPIC trainset.$N.$TOPIC 50 $N seed_out.$N.$TOPIC.arff $TOPIC $flag_allac_first_time $rules
-#                     flag_allac_first_time=$(($flag_allac_first_time+1))
-#                     cat label.$N.$TOPIC > /tmp/ssarp$N.$TOPIC
-#                     cd -
-#                     mv /tmp/ssarp$N.$TOPIC .
-#
-#                     cat sub_new$N.$TOPIC  | sort | uniq | join - rel.$TOPIC.fil | cut -d' ' -f1 | sed -e 's/^/1 /' > sub_new_positivo.$N
-#                     cat sub_new$N.$TOPIC   | sort | uniq | join - rel.$TOPIC.fil -v1 | cut -d' ' -f1 | sed -e 's/^/-1 /' > sub_new_negativo.$N
-#
-#                     cat ssarp$N.$TOPIC   | sort | uniq | join - rel.$TOPIC.fil | cut -d' ' -f1 | sed -e 's/^/1 /' > x_posit.$N
-#                     cat ssarp$N.$TOPIC   | sort | uniq | join - rel.$TOPIC.fil -v1 | cut -d' ' -f1 | sed -e 's/^/-1 /' > x_negat.$N
-#
-#                     cat x_posit.$N x_negat.$N | cut -d' ' -f2 | sort | uniq > ssarp$N.$TOPIC
-#                     ssarp_relevants=`wc -l < x_posit.$N`
-#
-#                     echo -e "${GREEN}Positives documents collected ... `wc -l < x_posit.$N`"
-#                     echo "Negative documents .............. `wc -l < x_negat.$N`"
-#                     echo -e "Total positives in sub sample ... `wc -l < sub_new_positivo.$N`${END}"
-#
-#             fi
-#
-#
-#
-#             aux=`wc -l < x_negat.$N`
-#             NotRel=$(($NotRel+`wc -l < x_negat.$N`))
-# #
-#             $DEBUG_MODE && echo "End of active learning step"
-#             ###########################################
-#
-#
-#
-#             RELFINDDOC=`wc -l < x_posit.$N`
-#             RELRATE=`echo "scale=4; $RELFINDDOC / $L" | bc`
-#             CURRENTREL=`cat  x_posit.[0-9][0-9] | wc -l`
-#
-#             alreadyLabeledDocs=`cat ssarp*  | wc -l`
-#             allDocs=`cat new[0-9][0-9].$TOPIC  | wc -l`
-#
-#             $DEBUG_MODE && echo "rel $RELFINDDOC L $L b $b  alreadyLabeledDocs $alreadyLabeledDocs  allDocs $allDocs REL $RELRATE CURRENTREL $CURRENTREL relevant docs `wc -l < rel.$TOPIC.fil` "
-#
-#
-#             aux=$((($RELFINDDOC*$L)/$b))
-#             Rel=$(($Rel+$aux*1000))
-#
-#             echo $RELFINDDOC $L $b $RELRATE $CURRENTREL >> rel.rate
-#             sort rel.$TOPIC.fil | sed -e 's/$/ 1/' > prel.$TOPIC
-#
-#             cut -d' ' -f1 prel.$TOPIC > rel.$TOPIC.fil
-#
-#             $DEBUG_MODE && echo "compute the Estimate ρ̂  of each round"
-#
-#             Temp_A=$(($RELFINDDOC*$L))
-#             Temp_B=$(($Temp_A/$b))
-#
-#             export Estimate=$(($Estimate+$Temp_B))
-#             echo "${N%.*} $Estimate" >> store_estimation
-#
-#             echo -e "${GREEN} $Temp_A $Temp_B $b $L Estimate rate is $Estimate"
-#
-#             NDUN=$((NDUN+L))
-#             L=$((L+(L+9)/10))
-#         fi
-#     done
-# done
+# $DEBUG_MODE && echo -e "${GREEN}Done.${END}"
+
+source ./preprocess $JUDGECLASS `echo $DEBUG_MODE` $TOPIC $QUERY
 
-bash ../training $TOPIC $QUERY $JUDGECLASS `echo $DEBUG_MODE`
+source ../training $TOPIC $QUERY $JUDGECLASS `echo $DEBUG_MODE` $KEYSIZE $VALSIZE
 
 echo "select the top 95% relevant documents  from the last ranking"
 echo " 20: Estimate ρ̂ = 1.05 "
@@ -579,9 +245,7 @@ python3 ../selectRound.py store_estimation $prevalence_int
 
 export j=`cat flagOut`
 
-export t=`wc -l < U$j`
-
-
+export t=`wc -l < new$j.$TOPIC`
 
 
 NumberDocument=$(($NDOCS-$t))
@@ -600,14 +264,10 @@ export relNumber=`cat result.$TOPIC | sort | uniq | join - goldendb | uniq | wc 
 NumberDocument=`cat result.$TOPIC | sort | uniq | wc -l`
 
 
-
-
 total=`wc -l < goldendb`
 recall=`echo "scale=5; ($relNumber / $total)" | bc`
 precisao=`echo "scale=5; ($relNumber / $NumberDocument)" | bc`
 echo "resultado final SCAL $TOPIC - $relNumber ------$NumberDocument  recall $recall  precisao $precisao"
-
-
 
 
 echo -e "${BLUE}calling second sampling strategy proposed by REVEAL ${END}"

--- a/main
+++ b/main
@@ -52,7 +52,7 @@ contains() {
 #==========================================================
 function show_usage() {
     echo "Usage: ./main [-s <samples>|--samples=<samples>]
-              [-c <corpus>|--corpus=<corpus>] [-d|--debug]
+              [-c <corpus>|--corpus=<corpus>] [-v|--verbose]
               [-o|--off-colors] -t <topic-list>|--topics <topic-list>
               [-h|--help]"
 }
@@ -83,8 +83,8 @@ function show_help() {
     echo "      one or more topics."
 
     echo ""
-    e_secondary "-d, --debug"
-    echo "      If specified, turns on the debug mode, showing verbose messages."
+    e_secondary "-v, --verbose"
+    echo "      If specified, verbose messages will be shown during execution."
 
     echo ""
     e_secondary "-o, --off-colors"
@@ -102,7 +102,7 @@ function show_help() {
 POSITIONAL=()                   # stores not recognized parameters
 SAMPLES=1
 CORPUS="toyDataset"
-DEBUG_MODE=false
+VERBOSE=false
 TOPICS_CONSIDERED="empty"      # dummy value for empty topic list verification
 
 sed -r -i "s/COLORS_ON=false/COLORS_ON=true/" colors
@@ -129,8 +129,8 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
 
-        -d | --debug )
-            DEBUG_MODE=true
+        -v | --verbose )
+            VERBOSE=true
             ;;
 
         -o | --off-colors )
@@ -232,17 +232,17 @@ for i in $(seq -f "%02g" ${SAMPLES}); do
         echo -e "${WHITE}Topic${END}:$TOPIC"
         echo -e "${WHITE}Query${END}:$QUERY"
 
-        source ./preprocess $CORPUS `echo $DEBUG_MODE` $TOPIC $QUERY
-        source ./training $TOPIC $QUERY $CORPUS `echo $DEBUG_MODE` $KEYSIZE $VALSIZE
+        source ./preprocess $CORPUS `echo $VERBOSE` $TOPIC $QUERY
+        source ./training $TOPIC $QUERY $CORPUS `echo $VERBOSE` $KEYSIZE $VALSIZE
 
         pushd $TOPIC
 
-        $DEBUG_MODE && echo "Select the top 95% relevant documents from the last ranking."
-        $DEBUG_MODE && echo "20: Estimate ρ̂ = 1.05."
+        $VERBOSE && echo "Select the top 95% relevant documents from the last ranking."
+        $VERBOSE && echo "20: Estimate ρ̂ = 1.05."
         export prevalence=`echo "scale=5; ($estimate * 1.05) / $TOTAL_DOCUMENTS" \
             | bc`
 
-        $DEBUG_MODE && echo "Prevalence: $prevalence"
+        $VERBOSE && echo "Prevalence: $prevalence"
 
         export m=`echo "scale=5; ($prevalence * $TOTAL_DOCUMENTS ) * 0.90" \
             | bc`
@@ -269,7 +269,7 @@ for i in $(seq -f "%02g" ${SAMPLES}); do
 
         cat ssarp* result_ranking.$TOPIC >> result.$TOPIC
 
-        $DEBUG_MODE && echo "t = $t; j = $j; documents_retrieved = $documents_retrieved; TOTAL_DOCUMENTS = $TOTAL_DOCUMENTS;"
+        $VERBOSE && echo "t = $t; j = $j; documents_retrieved = $documents_retrieved; TOTAL_DOCUMENTS = $TOTAL_DOCUMENTS;"
 
         export relevants_found=`cat result.$TOPIC \
             | sort \

--- a/main
+++ b/main
@@ -196,27 +196,6 @@ mkdir all_results
 rm -rf results
 mkdir results
 
-#----------------------------------------------------------------------
-# if data is already prepared, skips data extraction
-#----------------------------------------------------------------------
-if [ ! -f "${CORPUS}.svm.fil" ]; then
-    pushd Corpus
-
-    e_primary "Preparing dataset (executing dofast)..."
-    ./dofast "$CORPUS" $DEBUG_MODE
-    e_success "Done."
-
-    cp "$CORPUS".df ../"$CORPUS".df > /dev/null
-
-    cp "$CORPUS".svm.fil ../"$CORPUS".svm.fil
-
-    e_primary "Running feature compression SVD..."
-    ../svd/./script_create_svd.sh  ../$CORPUS.svm.fil 10
-    e_success "Done."
-
-    popd
-fi
-
 #-------------------------------------------------------------------------
 # runs the main code <SAMPLES> times
 #-------------------------------------------------------------------------
@@ -226,8 +205,6 @@ for i in $(seq -f "%02g" ${SAMPLES}); do
 
     rm -rf all_results/result-${i}
     mkdir all_results/result-${i}
-
-    # bash doAll_Baseline_4gram $CORPUS `echo "$DEBUG_MODE"` "${TOPICS_CONSIDERED[@]}"
 
     #---------------------------------------------------------------------
     # iterates over every topic:query pair, and executes the method for
@@ -239,7 +216,6 @@ for i in $(seq -f "%02g" ${SAMPLES}); do
         TOPIC="${TEXT[0]}"
 
         if ! contains $TOPIC "${TOPICS_CONSIDERED[@]}"; then
-            e_info "Skipping topic '$TOPIC'."
             continue
         fi
 
@@ -256,7 +232,78 @@ for i in $(seq -f "%02g" ${SAMPLES}); do
         echo -e "${WHITE}Topic${END}:$TOPIC"
         echo -e "${WHITE}Query${END}:$QUERY"
 
-        bash doAll_Baseline_4gram $CORPUS `echo "$DEBUG_MODE"` $TOPIC $QUERY
+        source ./preprocess $CORPUS `echo $DEBUG_MODE` $TOPIC $QUERY
+        source ./training $TOPIC $QUERY $CORPUS `echo $DEBUG_MODE` $KEYSIZE $VALSIZE
+
+        pushd $TOPIC
+
+        $DEBUG_MODE && echo "Select the top 95% relevant documents from the last ranking."
+        $DEBUG_MODE && echo "20: Estimate ρ̂ = 1.05."
+        export prevalence=`echo "scale=5; ($estimate * 1.05) / $TOTAL_DOCUMENTS" \
+            | bc`
+
+        $DEBUG_MODE && echo "Prevalence: $prevalence"
+
+        export m=`echo "scale=5; ($prevalence * $TOTAL_DOCUMENTS ) * 0.90" \
+            | bc`
+        prevalence_int=${m%.*}
+
+        python3 ../selectRound.py store_estimation $prevalence_int
+
+        export j=`cat flagOut`
+
+        export t=`wc -l < new$j.$TOPIC`
+
+        documents_retrieved=$(($TOTAL_DOCUMENTS - $t))
+
+        sort -k 2 -n inlr.out.$round.$TOPIC > sorted_ranking
+
+        tail -$documents_retrieved sorted_ranking \
+            | cut -d$'\t' -f1 > result_ranking.$TOPIC
+
+        n=$(($TOTAL_DOCUMENTS - $prevalence_int))
+
+        tail -$TOTAL_DOCUMENTS sorted_ranking \
+            | cut -d' ' -f1 \
+            | head -$n > result_plus.$TOPIC
+
+        cat ssarp* result_ranking.$TOPIC >> result.$TOPIC
+
+        $DEBUG_MODE && echo "t = $t; j = $j; documents_retrieved = $documents_retrieved; TOTAL_DOCUMENTS = $TOTAL_DOCUMENTS;"
+
+        export relevants_found=`cat result.$TOPIC \
+            | sort \
+            | uniq \
+            | join - goldendb \
+            | uniq \
+            | wc -l`
+
+        documents_retrieved=`cat result.$TOPIC \
+            | sort \
+            | uniq \
+            | wc -l`
+
+        total=`wc -l < goldendb`
+
+        recall=`echo "scale=5; ($relevants_found / $total)" \
+            | bc`
+
+        precision=`echo "scale=5; ($relevants_found / $documents_retrieved)" \
+            | bc`
+
+        e_secondary "Final result SCAL ${YELLOW}Topic:${END} $TOPIC"
+        echo -e "\tRelevants: $relevants_found"
+        echo -e "\tDocuments retrieved: $documents_retrieved"
+        echo -e "\tRecall: $recall"
+        echo -e "\tPrecision: $precision"
+
+        e_primary "Calling second sampling strategy proposed by REVEAL"
+        ../script_select_pairs.sh $TOPIC $JUDGECLASS $prevalence_int $rules 20
+
+        popd
+
+        mv $TOPIC "${RESULT_DIR}/"
+        rm $TOPIC.seed.doc
 
     done < "judgement/$CORPUS.topic.stemming.txt"
 

--- a/preprocess
+++ b/preprocess
@@ -10,7 +10,7 @@ source "${ABS_PATH}/handle_errors"
 source "${ABS_PATH}/colors"
 
 JUDGECLASS=$1; shift
-DEBUG_MODE=false; [[ $1 == "true" ]] && DEBUG_MODE=true; shift
+VERBOSE=false; [[ $1 == "true" ]] && VERBOSE=true; shift
 TOPIC=$1; shift
 QUERY=$1; shift
 
@@ -21,7 +21,7 @@ if [ ! -f "${JUDGECLASS}.svm.fil" ]; then
     pushd Corpus
 
     e_primary "Preparing dataset (executing dofast)..."
-    ./dofast "$JUDGECLASS" $DEBUG_MODE
+    ./dofast "$JUDGECLASS" $VERBOSE
     e_success "Done."
 
     cp "$JUDGECLASS".df ../"$JUDGECLASS".df > /dev/null
@@ -37,7 +37,7 @@ fi
 
 RESULT_DIR="result/${JUDGECLASS}"
 
-$DEBUG_MODE && e_primary "Creating directories to store results..."
+$VERBOSE && e_primary "Creating directories to store results..."
 
 try
 (
@@ -50,9 +50,9 @@ catch || {
     exit_on_error
 }
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
-$DEBUG_MODE && e_primary "Creating topic directory..."
+$VERBOSE && e_primary "Creating topic directory..."
 
 try
 (
@@ -65,9 +65,9 @@ catch || {
     exit_on_error
 }
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
-$DEBUG_MODE && e_primary "Creating goldendb..."
+$VERBOSE && e_primary "Creating goldendb..."
 
 try
 (
@@ -82,9 +82,9 @@ catch || {
     exit_on_error
 }
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
-$DEBUG_MODE && e_primary "Creating file with total number of docs..."
+$VERBOSE && e_primary "Creating file with total number of docs..."
 
 try
 (
@@ -96,7 +96,7 @@ catch || {
     exit_on_error
 }
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
 pushd $TOPIC
 
@@ -104,7 +104,7 @@ echo "$QUERY" > "$TOPIC".seed.doc
 
 ln -n ../$JUDGECLASS.svm.fil $JUDGECLASS.svm.fil
 
-$DEBUG_MODE && echo "Preparing 'docfils' file with all documents..."
+$VERBOSE && echo "Preparing 'docfils' file with all documents..."
 
 try
 (
@@ -120,9 +120,9 @@ catch || {
     exit_on_error
 }
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
-$DEBUG_MODE && echo "Preparing auxiliary and result files..."
+$VERBOSE && echo "Preparing auxiliary and result files..."
 
 try
 (
@@ -144,27 +144,27 @@ catch || {
     exit_on_error
 }
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
 cp $TOPIC.seed.doc ../$TOPIC.seed.doc
 
 popd
 
-$DEBUG_MODE && e_primary "Executing ./dofeaturesseed..."
-./dofeaturesseed $TOPIC.seed.doc $TOPIC $JUDGECLASS $DEBUG_MODE
-$DEBUG_MODE && e_success "Finished ./dofeaturesseed."
+$VERBOSE && e_primary "Executing ./dofeaturesseed..."
+./dofeaturesseed $TOPIC.seed.doc $TOPIC $JUDGECLASS $VERBOSE
+$VERBOSE && e_success "Finished ./dofeaturesseed."
 
 pushd $TOPIC
 
 # TODO: Adds error detection here.
-$DEBUG_MODE && e_primary "Preparing ../$JUDGECLASS.svm.fil (runs ../dosplit)..."
+$VERBOSE && e_primary "Preparing ../$JUDGECLASS.svm.fil (runs ../dosplit)..."
 
 sed -e 's/[^ ]*/0/' ../$JUDGECLASS.svm.fil \
     | ../dosplit
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
-$DEBUG_MODE && e_primary "Preparing $TOPIC.synthetic.seed..."
+$VERBOSE && e_primary "Preparing $TOPIC.synthetic.seed..."
 
 try
 (
@@ -176,7 +176,7 @@ catch || {
     exit_on_error
 }
 
-$DEBUG_MODE && e_success "Done."
+$VERBOSE && e_success "Done."
 
 #-------------------------------------------------------------------------
 # set kissdb parameters and execute it if database doesn't exists
@@ -189,7 +189,7 @@ export KEYSIZE=$((KEYSIZE+2))
 export VALSIZE=$((VALSIZE+2))
 
 if [ ! -f "../$JUDGECLASS.db" ]; then
-    $DEBUG_MODE && e_primary "Indexing $JUDGECLASS, keysize = $KEYSIZE, valsize = $VALSIZE"
+    $VERBOSE && e_primary "Indexing $JUDGECLASS, keysize = $KEYSIZE, valsize = $VALSIZE"
 
     try
     (
@@ -201,7 +201,7 @@ if [ ! -f "../$JUDGECLASS.db" ]; then
         exit_on_error
     }
 
-    $DEBUG_MODE && e_success "Done."
+    $VERBOSE && e_success "Done."
 fi
 
 popd

--- a/preprocess
+++ b/preprocess
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+#===============================================================================
+#       USAGE:  ./preprocess <judgeclass> <verbose> <topic> <query>
+#
+# DESCRIPTION: Creates and loads start up files, creates seed trainsets.
+#===============================================================================
+
+source "${ABS_PATH}/handle_errors"
+source "${ABS_PATH}/colors"
+
+JUDGECLASS=$1; shift
+DEBUG_MODE=false; [[ $1 == "true" ]] && DEBUG_MODE=true; shift
+TOPIC=$1; shift
+QUERY=$1; shift
+
+#----------------------------------------------------------------------
+# if data is already prepared, skips data extraction
+#----------------------------------------------------------------------
+if [ ! -f "${JUDGECLASS}.svm.fil" ]; then
+    pushd Corpus
+
+    e_primary "Preparing dataset (executing dofast)..."
+    ./dofast "$JUDGECLASS" $DEBUG_MODE
+    e_success "Done."
+
+    cp "$JUDGECLASS".df ../"$JUDGECLASS".df > /dev/null
+
+    cp "$JUDGECLASS".svm.fil ../"$JUDGECLASS".svm.fil
+
+    e_primary "Running feature compression SVD..."
+    ../svd/./script_create_svd.sh  ../$JUDGECLASS.svm.fil 10
+    e_success "Done."
+
+    popd
+fi
+
+RESULT_DIR="result/${JUDGECLASS}"
+
+$DEBUG_MODE && e_primary "Creating directories to store results..."
+
+try
+(
+    rm -rf "${RESULT_DIR}/${TOPIC}/"
+    mkdir -p "${RESULT_DIR}/${TOPIC}/"
+
+) 2> $STD_ERROR_OUT
+
+catch || {
+    exit_on_error
+}
+
+$DEBUG_MODE && e_success "Done."
+
+$DEBUG_MODE && e_primary "Creating topic directory..."
+
+try
+(
+    rm -rf $TOPIC
+    mkdir $TOPIC
+
+) 2> $STD_ERROR_OUT
+
+catch || {
+    exit_on_error
+}
+
+$DEBUG_MODE && e_success "Done."
+
+$DEBUG_MODE && e_primary "Creating goldendb..."
+
+try
+(
+cat judgement/qrels.$JUDGECLASS.list \
+    | grep "$TOPIC" \
+    | cut -d' ' -f3 \
+    | sort > $TOPIC/goldendb
+
+) 2> $STD_ERROR_OUT
+
+catch || {
+    exit_on_error
+}
+
+$DEBUG_MODE && e_success "Done."
+
+$DEBUG_MODE && e_primary "Creating file with total number of docs..."
+
+try
+(
+    echo `wc -l < "$JUDGECLASS".svm.fil` > N
+
+) 2> $STD_ERROR_OUT
+
+catch || {
+    exit_on_error
+}
+
+$DEBUG_MODE && e_success "Done."
+
+pushd $TOPIC
+
+echo "$QUERY" > "$TOPIC".seed.doc
+
+ln -n ../$JUDGECLASS.svm.fil $JUDGECLASS.svm.fil
+
+$DEBUG_MODE && echo "Preparing 'docfils' file with all documents..."
+
+try
+(
+    cut -d' ' -f1 ../$JUDGECLASS.svm.fil \
+        | sed -e 's/.*/& &/' > docfil
+
+    cut -d' ' -f1 docfil \
+        | cat -n > docfils
+
+) 2> $STD_ERROR_OUT
+
+catch || {
+    exit_on_error
+}
+
+$DEBUG_MODE && e_success "Done."
+
+$DEBUG_MODE && echo "Preparing auxiliary and result files..."
+
+try
+(
+    touch rel.$TOPIC.fil
+    touch prel.$TOPIC
+
+    rm -rf prevalence.rate
+    touch prevalence.rate
+
+    rm -rf rel.rate
+    touch rel.rate
+
+    rm -f new[0-9][0-9].$TOPIC tail[0-9][0-9].$TOPIC self*.$TOPIC gold*.$TOPIC
+    touch new00.$TOPIC
+
+) 2> $STD_ERROR_OUT
+
+catch || {
+    exit_on_error
+}
+
+$DEBUG_MODE && e_success "Done."
+
+cp $TOPIC.seed.doc ../$TOPIC.seed.doc
+
+popd
+
+$DEBUG_MODE && e_primary "Executing ./dofeaturesseed..."
+./dofeaturesseed $TOPIC.seed.doc $TOPIC $JUDGECLASS $DEBUG_MODE
+$DEBUG_MODE && e_success "Finished ./dofeaturesseed."
+
+pushd $TOPIC
+
+# TODO: Adds error detection here.
+$DEBUG_MODE && e_primary "Preparing ../$JUDGECLASS.svm.fil (runs ../dosplit)..."
+
+sed -e 's/[^ ]*/0/' ../$JUDGECLASS.svm.fil \
+    | ../dosplit
+
+$DEBUG_MODE && e_success "Done."
+
+$DEBUG_MODE && e_primary "Preparing $TOPIC.synthetic.seed..."
+
+try
+(
+    sed -e 's/[^ ]*/1/' svm.$TOPIC.seed.doc.fil > $TOPIC.synthetic.seed
+
+) 2> $STD_ERROR_OUT
+
+catch || {
+    exit_on_error
+}
+
+$DEBUG_MODE && e_success "Done."
+
+#-------------------------------------------------------------------------
+# set kissdb parameters and execute it if database doesn't exists
+#-------------------------------------------------------------------------
+KEYSIZE=$(awk 'BEGIN{a=0}{len = length($1); a=a<len?len:a}END{print a}' \
+    $JUDGECLASS.svm.fil)
+VALSIZE=$(awk 'BEGIN{a=0}{len = length($0); a=a<len?len:a}END{print a}' \
+    $JUDGECLASS.svm.fil)
+export KEYSIZE=$((KEYSIZE+2))
+export VALSIZE=$((VALSIZE+2))
+
+if [ ! -f "../$JUDGECLASS.db" ]; then
+    $DEBUG_MODE && e_primary "Indexing $JUDGECLASS, keysize = $KEYSIZE, valsize = $VALSIZE"
+
+    try
+    (
+        ../indexer $JUDGECLASS.svm.fil "$JUDGECLASS".db $KEYSIZE $VALSIZE
+
+    ) 2> $STD_ERROR_OUT
+
+    catch || {
+        exit_on_error
+    }
+
+    $DEBUG_MODE && e_success "Done."
+fi
+
+popd

--- a/training
+++ b/training
@@ -15,7 +15,7 @@ SOFIA="${ABS_PATH}/sofia-ml-read-only/sofia-ml"
 TOPIC=$1; shift
 QUERY=$1; shift
 JUDGECLASS=$1; shift
-DEBUG_MODE=false; [[ $1 == "true" ]] && DEBUG_MODE=true; shift
+VERBOSE=false; [[ $1 == "true" ]] && VERBOSE=true; shift
 KEYSIZE=$1; shift
 VALSIZE=$1; shift
 
@@ -48,7 +48,7 @@ for _round in $(seq -f "%02g" 0 99); do
     if [ $LABELED_DOCUMENTS -lt $TOTAL_DOCUMENTS ]; then
         export round=$_round
 
-        $DEBUG_MODE && e_primary "Preparing trainset..."
+        $VERBOSE && e_primary "Preparing trainset..."
 
         try
         (
@@ -66,9 +66,9 @@ for _round in $(seq -f "%02g" 0 99); do
             exit_on_error
         }
 
-        $DEBUG_MODE && e_success "Done."
+        $VERBOSE && e_success "Done."
 
-        $DEBUG_MODE && e_primary "Preparing seed..."
+        $VERBOSE && e_primary "Preparing seed..."
 
         try
         (
@@ -95,9 +95,9 @@ for _round in $(seq -f "%02g" 0 99); do
             exit_on_error
         }
 
-        $DEBUG_MODE && e_success "Done."
+        $VERBOSE && e_success "Done."
 
-        $DEBUG_MODE && e_primary "Adding content from seed to trainset..."
+        $VERBOSE && e_primary "Adding content from seed to trainset..."
 
         try
         (
@@ -113,7 +113,7 @@ for _round in $(seq -f "%02g" 0 99); do
             exit_on_error
         }
 
-        $DEBUG_MODE && e_success "Done."
+        $VERBOSE && e_success "Done."
 
         #-----------------------------------------------------------------
         # calculate the prevalence of relevant documents on training set
@@ -126,7 +126,7 @@ for _round in $(seq -f "%02g" 0 99); do
 
         echo $REL_ON_TRAINSET $NOT_REL_ON_TRAINSET $PREVALENCE_RATE >> prevalence.rate
 
-        $DEBUG_MODE && e_primary "Executing training algorithm (sofia-ml)..."
+        $VERBOSE && e_primary "Executing training algorithm (sofia-ml)..."
 
         try
         (
@@ -143,7 +143,7 @@ for _round in $(seq -f "%02g" 0 99); do
             exit_on_error
         }
 
-        $DEBUG_MODE && e_success "Done."
+        $VERBOSE && e_success "Done."
 
         #-----------------------------------------------------------------
         # tests the previously trained model
@@ -154,7 +154,7 @@ for _round in $(seq -f "%02g" 0 99); do
                     sleep 1
                 done
 
-                $DEBUG_MODE && e_primary "Testing previously trained model..."
+                $VERBOSE && e_primary "Testing previously trained model..."
 
                 try
                 (
@@ -168,7 +168,7 @@ for _round in $(seq -f "%02g" 0 99); do
                     exit_on_error
                 }
 
-                $DEBUG_MODE && e_success "Done."
+                $VERBOSE && e_success "Done."
 
             done
 
@@ -194,7 +194,7 @@ for _round in $(seq -f "%02g" 0 99); do
             }
         fi
 
-        $DEBUG_MODE && e_primary "Preparing ranking.$round.$TOPIC..."
+        $VERBOSE && e_primary "Preparing ranking.$round.$TOPIC..."
 
         try
         (
@@ -218,9 +218,9 @@ for _round in $(seq -f "%02g" 0 99); do
             exit_on_error
         }
 
-        $DEBUG_MODE && e_success "Done."
+        $VERBOSE && e_success "Done."
 
-        $DEBUG_MODE && e_primary "Preparing new$round.$TOPIC."
+        $VERBOSE && e_primary "Preparing new$round.$TOPIC."
 
         try
         (
@@ -240,9 +240,9 @@ for _round in $(seq -f "%02g" 0 99); do
             exit_on_error
         }
 
-        $DEBUG_MODE && e_success "Done."
+        $VERBOSE && e_success "Done."
 
-        $DEBUG_MODE && e_primary "Starting SCAL subsampling..."
+        $VERBOSE && e_primary "Starting SCAL subsampling..."
 
         if [ $SAMPLE_SIZE -le 30 ]; then
             sub_sample=$SAMPLE_SIZE
@@ -265,15 +265,15 @@ for _round in $(seq -f "%02g" 0 99); do
         sort rel.$TOPIC.fil | uniq > $TEMP_FILE
         mv $TEMP_FILE rel.$TOPIC.fil
 
-        $DEBUG_MODE && e_success "Done."
+        $VERBOSE && e_success "Done."
 
-        $DEBUG_MODE && e_primary "Starting SSARP stage..."
+        $VERBOSE && e_primary "Starting SSARP stage..."
 
         #-----------------------------------------------------------------
         #
         #-----------------------------------------------------------------
         if [ $not_relevants -lt 1 ] || [ $relevants -lt 1 ]; then
-            $DEBUG_MODE && e_secondary "\tStoring seed in ssarp file..."
+            $VERBOSE && e_secondary "\tStoring seed in ssarp file..."
 
             cp sub_new$round.$TOPIC ssarp$round.$TOPIC
 
@@ -312,7 +312,7 @@ for _round in $(seq -f "%02g" 0 99); do
         #-----------------------------------------------------------------
         else
 
-            $DEBUG_MODE && e_secondary "\tCreating files..."
+            $VERBOSE && e_secondary "\tCreating files..."
 
             # TODO: Check if the files temp_posit and temp_negat
             # could be united into a single file.
@@ -341,7 +341,7 @@ for _round in $(seq -f "%02g" 0 99); do
             #
             #-------------------------------------------------------------
             if [ $discretize -eq 0 ]; then
-                $DEBUG_MODE && e_secondary "\tGenerating bins"
+                $VERBOSE && e_secondary "\tGenerating bins"
 
                 python3 ../svd/convert_txt.py \
                     ../$JUDGECLASS.svm.fil.svd \
@@ -355,7 +355,7 @@ for _round in $(seq -f "%02g" 0 99); do
                 discretize=1
             fi
 
-            $DEBUG_MODE && e_secondary "\tConverting files to txt..."
+            $VERBOSE && e_secondary "\tConverting files to txt..."
 
             python3 ../svd/convert_txt.py \
                 trainset_labels.$round.$TOPIC \
@@ -371,7 +371,7 @@ for _round in $(seq -f "%02g" 0 99); do
             cp seed_out.$round.$TOPIC.arff ../SSARP/run/
             cp out.$round.$TOPIC.arff ../SSARP/run/
 
-            $DEBUG_MODE && e_primary "\tExecuting alac rules..."
+            $VERBOSE && e_primary "\tExecuting alac rules..."
 
             pushd ../SSARP/run/
             ./SSARPX.sh out.$round.$TOPIC \
@@ -388,7 +388,7 @@ for _round in $(seq -f "%02g" 0 99); do
 
             popd
 
-            $DEBUG_MODE && e_success "\tDone."
+            $VERBOSE && e_success "\tDone."
 
             mv /tmp/ssarp$round.$TOPIC .
 
@@ -430,16 +430,16 @@ for _round in $(seq -f "%02g" 0 99); do
 
             ssarp_relevants=`wc -l < x_posit.$round`
 
-            $DEBUG_MODE && e_info \
+            $VERBOSE && e_info \
                 "Positives documents collected ... `wc -l < x_posit.$round`"
-            $DEBUG_MODE && e_info \
+            $VERBOSE && e_info \
                 "Negative documents .............. `wc -l < x_negat.$round`"
-            $DEBUG_MODE && e_info \
+            $VERBOSE && e_info \
                 "Total positives in sub sample ... `wc -l < sub_new_positives.$round`"
 
         fi
 
-        $DEBUG_MODE && e_success "Active learning step finished."
+        $VERBOSE && e_success "Active learning step finished."
 
         #-----------------------------------------------------------------
         # statics calculation
@@ -454,14 +454,14 @@ for _round in $(seq -f "%02g" 0 99); do
         already_labeled_docs=`cat ssarp* | wc -l`
         all_docs=`cat new[0-9][0-9].$TOPIC | wc -l`
 
-        $DEBUG_MODE && e_info "\tRelevants ......... $rel_found_sample"
-        $DEBUG_MODE && e_info "\tSample size ....... $SAMPLE_SIZE"
-        $DEBUG_MODE && e_info "\tSub sample size ... $sub_sample"
-        $DEBUG_MODE && e_info "\tAlready labeled ... $already_labeled_docs"
-        $DEBUG_MODE && e_info "\tAll docs .......... $all_docs"
-        $DEBUG_MODE && e_info "\tRelevants rate .... $rel_rate"
-        $DEBUG_MODE && e_info "\tCurrent relevants . $current_rel"
-        $DEBUG_MODE && e_info "\tTotal relevants ... `wc -l < rel.$TOPIC.fil`"
+        $VERBOSE && e_info "\tRelevants ......... $rel_found_sample"
+        $VERBOSE && e_info "\tSample size ....... $SAMPLE_SIZE"
+        $VERBOSE && e_info "\tSub sample size ... $sub_sample"
+        $VERBOSE && e_info "\tAlready labeled ... $already_labeled_docs"
+        $VERBOSE && e_info "\tAll docs .......... $all_docs"
+        $VERBOSE && e_info "\tRelevants rate .... $rel_rate"
+        $VERBOSE && e_info "\tCurrent relevants . $current_rel"
+        $VERBOSE && e_info "\tTotal relevants ... `wc -l < rel.$TOPIC.fil`"
 
         relevants=$(($relevants + \
             ($rel_found_sample * $SAMPLE_SIZE) / $sub_sample))
@@ -477,7 +477,7 @@ for _round in $(seq -f "%02g" 0 99); do
         echo "${round%.*} $estimate" >> store_estimation
 
 
-        $DEBUG_MODE && e_secondary "Estimate rate is: $estimate"
+        $VERBOSE && e_secondary "Estimate rate is: $estimate"
 
 
         LABELED_DOCUMENTS=$(($LABELED_DOCUMENTS + $SAMPLE_SIZE))

--- a/training
+++ b/training
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #===============================================================================
-#       USAGE:  ./training <topic> <query> <debug>
+#       USAGE:  ./training <topic> <query> <judgeclass> <verbose>
+#                          <keysize> <valsize>
 #
 # DESCRIPTION:  Contains the training loop that judges files as relevant or not.
 #===============================================================================
@@ -15,8 +16,14 @@ TOPIC=$1; shift
 QUERY=$1; shift
 JUDGECLASS=$1; shift
 DEBUG_MODE=false; [[ $1 == "true" ]] && DEBUG_MODE=true; shift
+KEYSIZE=$1; shift
+VALSIZE=$1; shift
+
 MAXTHREADS=5
 rules=5
+
+pushd $TOPIC
+
 
 R=100                                   # Document sample size going to trainset
 LAMBDA=0.0001                           # Lambda parameter for SVM
@@ -34,19 +41,12 @@ not_relevants=0                          # Documents not relevant so far
 relevants=0                              # Documents relevant so far
 
 #-------------------------------------------------------------------------
-# parameters for kissdb, later this will be calculated somewhere else
-#-------------------------------------------------------------------------
-KEYSIZE=$(awk 'BEGIN{a=0}{len = length($1); a=a<len?len:a}END{print a}' $JUDGECLASS.svm.fil)
-VALSIZE=$(awk 'BEGIN{a=0}{len = length($0); a=a<len?len:a}END{print a}' $JUDGECLASS.svm.fil)
-KEYSIZE=$((KEYSIZE+2))
-VALSIZE=$((VALSIZE+2))
-
-#-------------------------------------------------------------------------
 # performs the 100 looping rounds
 #-------------------------------------------------------------------------
-for round in $(seq -f "%02g" 0 99); do
+for _round in $(seq -f "%02g" 0 99); do
 
     if [ $LABELED_DOCUMENTS -lt $TOTAL_DOCUMENTS ]; then
+        export round=$_round
 
         $DEBUG_MODE && e_primary "Preparing trainset..."
 
@@ -341,7 +341,7 @@ for round in $(seq -f "%02g" 0 99); do
             #
             #-------------------------------------------------------------
             if [ $discretize -eq 0 ]; then
-                $DEBUG_MODE && e_secondary "\t Generating bins"
+                $DEBUG_MODE && e_secondary "\tGenerating bins"
 
                 python3 ../svd/convert_txt.py \
                     ../$JUDGECLASS.svm.fil.svd \
@@ -485,5 +485,10 @@ for round in $(seq -f "%02g" 0 99); do
     fi
 done
 
-export Estimate=estimate
-export NDOCS=TOTAL_DOCUMENTS
+# TODO: Change this approach
+export estimate=$estimate
+export TOTAL_DOCUMENTS=$TOTAL_DOCUMENTS
+export rules=$rules
+export N=$round
+
+popd


### PR DESCRIPTION
closes #13 

# Changes overview
- Adds preprocessing code to another file;
- Changes the option `-d, --debug` to `-v, --verbose`;

# Variables and files changelog
See this if necessary to understand the current code.

Most of these changes are also in previous versions.
## General Notes
- `PURPOSE` variable removed;
- The `baseline` and `debug` sub directories were removed;
- `CORPLIST` was removed;
- `doAll_Baseline_4gram` no longer used;

## Variables
- `NODCS` → `TOTAL_DOCUMENTS`;
- `NDUN` → `LABELED_DOCUMENTS`;
- `L` → `SAMPLE_SIZE`;
- `b` → `sub_sample`;
- `flag_discretize` → `discretize`;
- `NotRel` → `not_relevants`;
- `Rel` → `relevants`;
- `N` → `round`;
- `CORP` → `JUDGECLASS`;
- `RELTRAINDOC` → `REL_ON_TRAINSET`;
- `NOTRELTRAINDOC` → `NOT_REL_ON_TRAINSET`;
- `PREVALENCERATE` → `PREVALENCE_RATE`;
- `RELFINDDOC` → `rel_found_sample`;
- `RELRATE` → `rel_rate`;
- `CURRENTREL` → `current_rel`;
- `alreadyLabeledDocs` → `already_labeled_docs`;
- `allDocs` → `all_docs`;
- `Estimate` → `estimate`;
- `relNumber` → `relevants_found`;
- `NumberDocument` → `documents_retrieved`;

## Files
- `x` → `intermediate_seed`;
- `saida_classificador` → `classifier_output`;
- `sub_new_positivo[0-9][0-9]` → `sub_new_positives[0-9][0-9]`;
- `sub_new_negativo[0-9][0-9]` → `sub_new_negatives[0-9][0-9]`;
- `trainsetB.[0-9][0-9].TOPIC` → `trainset_labels.[0-9][0-9].TOPIC`;
- `seed_ssarpB.TOPIC` → `seed_ssarp_labels.TOPIC`;
